### PR TITLE
Merging coordinating conjunctives in chunking

### DIFF
--- a/chunking.py
+++ b/chunking.py
@@ -98,7 +98,6 @@ class ChunkPipeline:
                     chunk_sentences[i - 1] = merged_sentence
                     chunk_sentences.pop(i)
 
-
         # Add stride to chunks
         # NOTE: In the future, look into adding right stride to potentially only the first issue. 
         # Cannot add right stride to all chunks because else we cause some chunks to start with a coordinating conjunctive


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [ ] Bugfix
- [x] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/E6hfg2Mi/33-merge-sentences-with-connectives-during-chunking)

## Proposed Changes
Each chunk is composed of sentences, some of these sentences start with coordinating conjunctives (e.g. "and", "but" etc.) when we conduct stride addition in the chunking algorithm we might result in some final chunks starting with a coordinating conjunctive, this PR aims at mitigating this issues by ensuring that no sentence in a given chunk starts with a coordinating conjunctive prior to adding stride

## Screenshots
N/A
