### PR TITLE
refactor: use JSON file for ASR output

### DIFF
--- a/asr/asr_pipeline.py
+++ b/asr/asr_pipeline.py
@@ -94,10 +94,14 @@ class ASRPipeline:
 
 if __name__ == "__main__":
     import argparse
+    import json
+    from datetime import datetime
 
     parser = argparse.ArgumentParser()
     parser.add_argument("file_path", help="audio/video file")
     args = parser.parse_args()
     pipe = ASRPipeline()
     chunks, duration = pipe(file_path=args.file_path)
-    print(chunks, duration)
+    data = {"chunks": chunks, "duration": duration}
+    with open(datetime.now().strftime("%Y%m%d_%H%M%S.json"), "w") as f:
+        json.dump(data, f)


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [ ] Bugfix
- [x] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/XXXX)

## Proposed Changes

The output of the asr script is now a json file with the current timestamp. The JSON file also includes the duration.

## Screenshots
N/A
