### PR TITLE
refactor: update min chunk duration to 60s

### DIFF
--- a/src/alinet/chunking/pipeline.py
+++ b/src/alinet/chunking/pipeline.py
@@ -27,8 +27,8 @@ class ChunkPipeline:
         self,
         chunks: list[dict[str, str | tuple[float, float]]],
         audio_length: float,
-        stride_length=80,
-        min_duration=120,
+        stride_length=90,
+        min_duration=60,
     ) -> list[dict[str, str | tuple[float, float]]]:
         """
         :param chunks: transcript chunks with chunk-level timestamps


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [ ] Bugfix
- [ ] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Refactor

## Proposed Changes

This PR decreases the minimum chunk duration to 60s from 120s. We had set the duration to 120s previously since ran our first experiment using that before implementing stride. I think its better to generate more questions since they would get filtered out anyway.

## Screenshots
N/A
