### PR TITLE
refactor: change generated question return type to be an indexed dictionary

### DIFF
--- a/src/alinet/chunking/similarity.py
+++ b/src/alinet/chunking/similarity.py
@@ -74,12 +74,12 @@ def filter_questions_by_retention_rate(
 
     Parameters:
     - sim_scores (list): List of similarity scores.
-    - generated_questions (list): Dictionary of generated questions with respective indexes.
+    - generated_questions (dict): Dictionary of generated questions with respective indexes.
     - similarity_threshold (float): Threshold for similarity scores.
     - filtering_threshold (float): Threshold for the retention rate.
 
     Returns:
-    list: A Dictionary of filtered questions based on the retention rate and similarity threshold.
+    dict: A Dictionary of filtered questions based on the retention rate and similarity threshold.
     """
     filtered_questions = {}
 

--- a/src/alinet/qg/pipeline.py
+++ b/src/alinet/qg/pipeline.py
@@ -31,7 +31,7 @@ class QGPipeline:
         start_word=None,
         max_tokens=32,
         num_beams=4,
-    ) -> list[str]:
+    ) -> dict[int, str]:
         """
         Generates one question per document (context)
 
@@ -74,5 +74,5 @@ class QGPipeline:
         )
 
         result_dict = {i: question for i, question in enumerate(generated_questions)}
-        
+
         return result_dict


### PR DESCRIPTION
- This allows us to identify which chunks correspond to which question even after the automated relevance filtering.

## PR Type

<!---What kind of change does this PR introduce?--->

- [ ] Bugfix
- [x] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/XXXX)

## Proposed Changes
- Changed generated question return type to be an indexed dictionary instead of a list of questions
Before this modification, we could presume that the chunks from which the questions were derived were in chronological order to the question being generated. In other words, the first question originated from the first chunk. However, after applying relevance filtering, which may randomly remove questions and disrupt the order, this assumption would no longer hold true. This allows us to identify which chunks correspond to which question
even after the automated relevance filtering.


## Screenshots
N/A
