### PR TITLE
feat: add BART pretraining script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,6 +85,7 @@ python run_bart_dlm_flax.py \
 To report to [W&B](https://wandb.ai/), set the following environment variables:
 
 ```shell
+export WANDB_PROJECT="mmqg"
 export WANDB_API_KEY="..."
 export WANDB_NAME="pubmed-bart-base"
 ```

--- a/scripts/run_bart_dlm_flax.py
+++ b/scripts/run_bart_dlm_flax.py
@@ -601,7 +601,7 @@ def main():
         model_args.token = model_args.use_auth_token
 
     # Initialize wandb
-    wandb.init(project="mmqg")
+    wandb.init()
     wandb.config.update(training_args.to_dict())
 
     if (


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [ ] Bugfix
- [x] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/VNL3pY1R/32-pretrain-plm-on-large-text-corpus)

## Proposed Changes

This PR adds the BART pretraining script adapted from transformers upstream example. 
The main changes include:
- Introduced `text_column_name` argument to specify text column
- Integrated [W&B](https://wandb.ai/) Python client library
- Removed HuggingFace telemetry

This PR also does not add the flax library dependencies since this is a one-shot script and we don't currently use flax for our inference.

## Screenshots
N/A
