### PR TITLE
fix: return original question on empty slide chunks

### DIFF
--- a/src/alinet/main.py
+++ b/src/alinet/main.py
@@ -4,7 +4,7 @@ from alinet.chunking.similarity import (
     filter_questions_by_retention_rate,
 )
 from alinet.chunking.video import slide_chunking, save_video_clips
-
+import warnings
 
 def baseline(
     video_path: str,
@@ -27,6 +27,12 @@ def baseline(
     generated_questions = qg_pipe(text_chunks)
 
     slide_chunks = slide_chunking(video_path)
+    if len(slide_chunks) == 0:
+        warnings.warn(
+            "Slide chunks are empty. Question filtering step is skipped. Non-filtered questions are returned"
+        )
+        return generated_questions
+
     sim_scores = get_similarity_scores(transcript_chunks, slide_chunks)
     filtered_questions = filter_questions_by_retention_rate(
         sim_scores, generated_questions, similarity_threshold, filtering_threshold


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [x] Bugfix
- [ ] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/XXXX)

## Proposed Changes
Filtering step was bugging out in some cases (short video, no slides in video) causing slide chunks being empty. Changed it so that if slide chunks are empty than we just return the non-filtered questions.

## Screenshots
![image](https://github.com/ram02z/alinet/assets/86851834/e6695c87-2eb9-42fd-af42-e983838e2ebd)

