### PR TITLE
refactor: make database a singleton

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,7 +9,7 @@ from transformers import HfArgumentParser
 SRC_DIR = os.path.join(os.path.dirname(__file__), "src")
 sys.path.append(SRC_DIR)
 
-from alinet import baseline, qg, asr  # noqa: E402
+from alinet import baseline, qg, rag, asr  # noqa: E402
 
 
 @dataclass
@@ -48,7 +48,8 @@ if __name__ == "__main__":
 
     if args.verbose:
         transformers.logging.set_verbosity(transformers.logging.DEBUG)
-
+    # Instantiate database singleton instance
+    rag.Database()
     pdfs_bytes: list[bytes] = []
     for doc_path in args.doc_paths:
         with open(doc_path, "rb") as f:

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import tempfile
 
 SRC_DIR = os.path.join(os.path.dirname(__file__), "src")
 sys.path.append(SRC_DIR)
-from alinet import asr, qg, baseline  # noqa: E402
+from alinet import asr, qg, rag, baseline  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+async def startup_event():
+    # Instantiate database singleton instance
+    rag.Database()
+
+
+app.add_event_handler("startup", startup_event)
 
 
 @app.post("/generate_questions")

--- a/src/alinet/main.py
+++ b/src/alinet/main.py
@@ -27,7 +27,7 @@ def baseline(
     if len(pdfs_bytes) != 0:
         # Supplementary material
         db = Database()
-        collection: Collection = db.create_collection(db.client)
+        collection: Collection = db.create_collection()
         db.store_documents(collection, pdfs_bytes=pdfs_bytes)
         text_chunks = [
             db.add_relevant_context_to_source(context=chunk.text, collection=collection)

--- a/src/alinet/main.py
+++ b/src/alinet/main.py
@@ -26,7 +26,9 @@ def baseline(
     # TODO: We might want to move this instantiate of the DB elsewhere, but I'm just gonna put it here for now
     if len(pdfs_bytes) != 0:
         # Supplementary material
-        db = Database()
+        # Get database singleton instance
+        db = Database._instance
+        print(db)
         collection: Collection = db.create_collection()
         db.store_documents(collection, pdfs_bytes=pdfs_bytes)
         text_chunks = [

--- a/src/alinet/rag/db.py
+++ b/src/alinet/rag/db.py
@@ -40,6 +40,13 @@ nlp.add_pipe("sentencizer")
 
 
 class Database:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls, *args, **kwargs)
+        return cls._instance
+
     def __init__(
         self,
         pretrained_bart_tokenizer_name: Model = Model.BALANCED_RESOLVED,


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [x] Refactor
- [ ] Bugfix
- [ ] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/XXXX)

## Proposed Changes

Reasons behind my decisions

```if __name__ == "__main__":
    import uvicorn
    # Assume we create DB here
    uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)
```
1. 
- Problem/Reasoning: We can can't create the DB in the `__main__`  shown in the comment. When `uvicorn.run` is called I think it effectively creates a new process so even if we used a singleton it doesn't matter since there would two different processes (The one were we instantiated our DB and the one were we created our server). 

- Solution: I discovered I use a FastAPI startup handler to launch the database which makes it part of the same process.


2. 
- Problem: I did a test pretending to be 2 users and our systems is sequential meaning if User1 uploads a video and User2 uploads a video. User2 has to wait for User1's video to finish processing and then wait for their video to finish processing. 

- N/A Solution: We can't really run each user in parallel due to our hardware limitations

3. 
-  Problem: Sequential users made me think that we shouldn't put the create_collection as part of the initial database setup because if we had two or more users then all the users would be sharing the same collection
- Potential Solution: We could make them share the collection but then I think once we finish processing their PDFs we need to delete those from the collection.

- Solution 1 (Current):, Without explicitly tracking users and making collections for separate users. I think the way we are doing it is fine (it's similar to the approach above), when a person uploads the PDFs the existing collection gets cleared and a new one gets created.

## Screenshots
N/A
