### PR TITLE
BugFix: Add unique id to uploaded files

### DIFF
--- a/web_app/src/App.tsx
+++ b/web_app/src/App.tsx
@@ -69,10 +69,7 @@ export default function App() {
           <h2>Upload videos / supplementary documents</h2>
 
           <div className="video-table-container">
-            <DragDrop
-              filesWithId={filesWithId}
-              setFilesWithId={setFilesWithId}
-            />
+            <DragDrop setFilesWithId={setFilesWithId} />
 
             <FileList
               filesWithId={filesWithId}

--- a/web_app/src/App.tsx
+++ b/web_app/src/App.tsx
@@ -18,8 +18,13 @@ export interface Question {
   score: number
 }
 
+export interface FileWithId {
+  id: string
+  file: File
+}
+
 export default function App() {
-  const [files, setFiles] = useState<File[]>([])
+  const [filesWithId, setFilesWithId] = useState<FileWithId[]>([])
   const [selection, setSelection] = useState<string[]>([])
   const [questions, setQuestions] = useState<Question[]>([])
   const [loading, setLoading] = useState<boolean>(false)
@@ -27,8 +32,8 @@ export default function App() {
   const generateQuestions = async () => {
     setLoading(true)
     const formData = new FormData()
-    files.forEach((file) => {
-      formData.append('files', file)
+    filesWithId.forEach((filesWithId) => {
+      formData.append('files', filesWithId.file)
     })
 
     try {
@@ -65,13 +70,13 @@ export default function App() {
 
           <div className="video-table-container">
             <DragDrop
-              files={files}
-              setFiles={setFiles}
+              filesWithId={filesWithId}
+              setFilesWithId={setFilesWithId}
             />
 
             <FileList
-              files={files}
-              setFiles={setFiles}
+              filesWithId={filesWithId}
+              setFilesWithId={setFilesWithId}
             />
           </div>
         </div>
@@ -80,7 +85,7 @@ export default function App() {
           <Button
             loading={loading}
             onClick={generateQuestions}
-            disabled={files.length === 0 || loading}
+            disabled={filesWithId.length === 0 || loading}
             className="generate-question-btn"
           >
             <IconSettingsCog className="setting-icon" /> Generate Questions

--- a/web_app/src/components/DragDrop.tsx
+++ b/web_app/src/components/DragDrop.tsx
@@ -4,22 +4,34 @@ import { Dropzone, MIME_TYPES } from '@mantine/dropzone'
 import { useEffect } from 'react'
 import classes from './DragDrop.module.css'
 import cx from 'clsx'
+import { FileWithId } from '../App'
+import { v4 as uuidv4 } from 'uuid'
 
 export interface DragDropProps {
-  files: File[]
-  setFiles: any
+  filesWithId: FileWithId[]
+  setFilesWithId: any
 }
 
-export const DragDrop = ({ files, setFiles }: DragDropProps) => {
+export const DragDrop = ({ filesWithId, setFilesWithId }: DragDropProps) => {
   useEffect(() => {
-    console.log(files)
-  }, [files])
+    console.log(filesWithId)
+  }, [filesWithId])
 
   return (
     <Dropzone
       className={cx(classes.dragdrop)}
       onDrop={(files: File[]) => {
-        setFiles((prevFiles: File[]) => [...prevFiles, ...files])
+        const filesWithId = files.map((file) => {
+          return {
+            id: uuidv4(),
+            file: file,
+          }
+        })
+
+        setFilesWithId((prevFiles: FileWithId[]) => [
+          ...prevFiles,
+          ...filesWithId,
+        ])
       }}
       onReject={(files) => console.log('rejected files', files)}
       accept={[MIME_TYPES.mp4, MIME_TYPES.pdf]}

--- a/web_app/src/components/DragDrop.tsx
+++ b/web_app/src/components/DragDrop.tsx
@@ -1,22 +1,16 @@
 import { Group, Text, rem } from '@mantine/core'
 import { IconUpload, IconFileUpload, IconX } from '@tabler/icons-react'
 import { Dropzone, MIME_TYPES } from '@mantine/dropzone'
-import { useEffect } from 'react'
 import classes from './DragDrop.module.css'
 import cx from 'clsx'
 import { FileWithId } from '../App'
 import { v4 as uuidv4 } from 'uuid'
 
 export interface DragDropProps {
-  filesWithId: FileWithId[]
   setFilesWithId: any
 }
 
-export const DragDrop = ({ filesWithId, setFilesWithId }: DragDropProps) => {
-  useEffect(() => {
-    console.log(filesWithId)
-  }, [filesWithId])
-
+export const DragDrop = ({ setFilesWithId }: DragDropProps) => {
   return (
     <Dropzone
       className={cx(classes.dragdrop)}

--- a/web_app/src/components/FileList.tsx
+++ b/web_app/src/components/FileList.tsx
@@ -16,9 +16,9 @@ export const FileList = ({ filesWithId, setFilesWithId }: FileListProps) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [previewModalOpen, setPreviewModalOpen] = useState(false)
 
-  const handleRemoveFile = (id: string) => {
+  const handleRemoveFile = (idToRemove: string) => {
     setFilesWithId((prevFiles: FileWithId[]) =>
-      prevFiles.filter((fileWithId: FileWithId) => fileWithId.id !== id)
+      prevFiles.filter((fileWithId: FileWithId) => fileWithId.id !== idToRemove)
     )
   }
 
@@ -29,7 +29,7 @@ export const FileList = ({ filesWithId, setFilesWithId }: FileListProps) => {
 
   // @ts-ignore
   const filesExpand = filesWithId.map((fileWithId: FileWithId) => (
-    <Table.Tr key={fileWithId.file.name}>
+    <Table.Tr key={fileWithId.id}>
       <Table.Td className={classes.tdName}>
         <Group>
           <Text>{fileWithId.file.name}</Text>

--- a/web_app/src/components/FileList.tsx
+++ b/web_app/src/components/FileList.tsx
@@ -1,36 +1,42 @@
-import cx from "clsx";
-import { useState } from "react";
-import { Table, ScrollArea, ActionIcon, Text, Group } from "@mantine/core";
-import classes from "./FileList.module.css";
-import { IconExternalLink, IconX } from "@tabler/icons-react";
-import { FilePreviewModal } from "./FilePreviewModal.tsx";
+import cx from 'clsx'
+import { useState } from 'react'
+import { Table, ScrollArea, ActionIcon, Text, Group } from '@mantine/core'
+import classes from './FileList.module.css'
+import { IconExternalLink, IconX } from '@tabler/icons-react'
+import { FilePreviewModal } from './FilePreviewModal.tsx'
+import { FileWithId } from '../App.tsx'
 
 export interface FileListProps {
-  files: File[];
-  setFiles: any;
+  filesWithId: FileWithId[]
+  setFilesWithId: any
 }
 
-export const FileList = ({ files, setFiles }: FileListProps) => {
-  const [scrolled, setScrolled] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [previewModalOpen, setPreviewModalOpen] = useState(false);
+export const FileList = ({ filesWithId, setFilesWithId }: FileListProps) => {
+  const [scrolled, setScrolled] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [previewModalOpen, setPreviewModalOpen] = useState(false)
 
-  const handleRemoveFile = (index: number) => {
-    setFiles((prevFiles: File[]) => prevFiles.filter((_, i) => i !== index));
-  };
+  const handleRemoveFile = (id: string) => {
+    setFilesWithId((prevFiles: FileWithId[]) =>
+      prevFiles.filter((fileWithId: FileWithId) => fileWithId.id !== id)
+    )
+  }
 
   const handleFileClick = (file: File) => {
-    setSelectedFile(file);
-    setPreviewModalOpen(true);
-  };
+    setSelectedFile(file)
+    setPreviewModalOpen(true)
+  }
 
   // @ts-ignore
-  const filesExpand = files.map((file, index) => (
-    <Table.Tr key={file.name}>
+  const filesExpand = filesWithId.map((fileWithId: FileWithId) => (
+    <Table.Tr key={fileWithId.file.name}>
       <Table.Td className={classes.tdName}>
         <Group>
-          <Text>{file.name}</Text>
-          <ActionIcon onClick={() => handleFileClick(file)} variant="light">
+          <Text>{fileWithId.file.name}</Text>
+          <ActionIcon
+            onClick={() => handleFileClick(fileWithId.file)}
+            variant="light"
+          >
             <IconExternalLink />
           </ActionIcon>
         </Group>
@@ -39,13 +45,13 @@ export const FileList = ({ files, setFiles }: FileListProps) => {
         <ActionIcon
           color="red"
           variant="filled"
-          onClick={() => handleRemoveFile(index)}
+          onClick={() => handleRemoveFile(fileWithId.id)}
         >
           <IconX />
         </ActionIcon>
       </Table.Td>
     </Table.Tr>
-  ));
+  ))
 
   return (
     <>
@@ -73,5 +79,5 @@ export const FileList = ({ files, setFiles }: FileListProps) => {
         />
       )}
     </>
-  );
-};
+  )
+}


### PR DESCRIPTION
## PR Type

<!---What kind of change does this PR introduce?--->

- [x] Bugfix
- [ ] Feature
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests

[Trello Link](https://trello.com/c/XXXX)

## Proposed Changes
Previously the uploaded files through the dropzone this not have unique ids attached, meaning that the corresponding table listing the files uses the index for each row's key. This can cause unexpected bugs.

This change updates so that when a file is uploaded a unique id is attached to it, and that id is used in the rendering of the rows.

## Screenshots
N/A
